### PR TITLE
Changing 'print' usage to 'log.debug'

### DIFF
--- a/src/compositekey/core/management/sql.py
+++ b/src/compositekey/core/management/sql.py
@@ -1,7 +1,11 @@
+import logging
+
 from django.core.management import sql
 from django.db import models
 
 __author__ = 'fabio'
+
+log = logging.getLogger(__name__)
 
 def sql_delete(app, style, connection):
     "Returns a list of the DROP TABLE SQL statements for the given app."
@@ -50,5 +54,5 @@ sql_delete._sign = "monkey patch by compositekey"
 
 def activate_sql_delete_monkey_patch():
    if not hasattr(sql.sql_delete, "_sign"):
-        print "activate_sql_delete_monkey_patch"
+        log.info("activate_sql_delete_monkey_patch")
         sql.sql_delete = sql_delete

--- a/src/compositekey/db/backends/__init__.py
+++ b/src/compositekey/db/backends/__init__.py
@@ -1,7 +1,10 @@
+import logging
+
 from django.db.backends import BaseDatabaseIntrospection
 
 __author__ = 'fabio'
 
+log = logging.getLogger(__name__)
 
 def sequence_list(self):
     "Returns a list of information about all DB sequences for all models in all apps."
@@ -32,5 +35,6 @@ sequence_list._sign = "monkey patch by compositekey"
 
 def activate_sequence_list_monkey_patch():
     if not hasattr(BaseDatabaseIntrospection.sequence_list, "_sign"):
-        print "activate_sequence_list_monkey_patch"
+        log.debug("activate_sequence_list_monkey_patch")
         BaseDatabaseIntrospection.sequence_list = sequence_list
+        

--- a/src/compositekey/db/backends/creation.py
+++ b/src/compositekey/db/backends/creation.py
@@ -1,7 +1,10 @@
+import logging
+
 from django.db.backends.creation import BaseDatabaseCreation
 
 __author__ = 'fabio'
 
+log = logging.getLogger(__name__)
 
 def sql_create_model(self, model, style, known_models=set()):
     """
@@ -114,7 +117,8 @@ sql_for_pending_references._sign = "monkey patch by compositekey"
 
 def activate_sql_create_model_monkey_patch():
     if not hasattr( BaseDatabaseCreation.sql_create_model, "_sign"):
-        print "activate_sql_create_model_monkey_patch"
+        log.debug("activate_sql_create_model_monkey_patch")
         BaseDatabaseCreation.sql_create_model = sql_create_model
         BaseDatabaseCreation.sql_indexes_for_model = sql_indexes_for_model
         BaseDatabaseCreation.sql_for_pending_references = sql_for_pending_references
+        

--- a/src/compositekey/db/backends/oracle/base.py
+++ b/src/compositekey/db/backends/oracle/base.py
@@ -1,5 +1,9 @@
 __author__ = 'fabio'
 
+import logging
+
+log = logging.getLogger(__name__)
+
 def sequence_reset_sql(self, style, model_list):
     from django.db import models
     from django.db.backends.oracle.base import _get_sequence_reset_sql
@@ -40,5 +44,6 @@ def activate_sequence_reset_sql_monkey_patch():
         from django.db.backends.oracle.base import DatabaseOperations
         # monkey patch
         if not hasattr(DatabaseOperations.sequence_reset_sql, "_sign"):
-            print "activate_sequence_reset_sql_monkey_patch"
+            log.debug("activate_sequence_reset_sql_monkey_patch")
             DatabaseOperations.sequence_reset_sql = sequence_reset_sql
+            

--- a/src/compositekey/db/backends/postgresql_psycopg2/operations.py
+++ b/src/compositekey/db/backends/postgresql_psycopg2/operations.py
@@ -1,5 +1,8 @@
 __author__ = 'aldaran'
 
+import logging
+
+log = logging.getLogger(__name__)
 
 def sequence_reset_sql(self, style, model_list):
     from django.db import models
@@ -50,5 +53,6 @@ def activate_pg_sequence_reset_sql_monkey_patch():
         from django.db.backends.postgresql_psycopg2.operations import DatabaseOperations
         # monkey patch
         if not hasattr(DatabaseOperations.sequence_reset_sql, "_sign"):
-            print "activate_sequence_reset_sql_monkey_patch"
+            log.debug("activate_sequence_reset_sql_monkey_patch")
             DatabaseOperations.sequence_reset_sql = sequence_reset_sql
+            

--- a/src/compositekey/db/models/fields/related.py
+++ b/src/compositekey/db/models/fields/related.py
@@ -1,3 +1,5 @@
+import logging
+
 from django.db.models import signals
 import operator
 
@@ -9,6 +11,8 @@ from compositekey.db.models.base import patched_model_init
 from compositekey.db.models.sql.column import MultiColumn
 
 __all__ = ['activate_fk_monkey_patch',]
+
+log = logging.getLogger(__name__)
 
 def identity(self, value): return value
 
@@ -89,5 +93,5 @@ def wrap_fk_monkey_patch(ori_init, ori_contribute_to_class):
 def activate_fk_monkey_patch():
     # monkey patch
     if not hasattr(ForeignKey.contribute_to_class, "_sign"):
-        print "activate_fk_monkey_patch"
+        log.debug("activate_fk_monkey_patch")
         ForeignKey.__init__, ForeignKey.contribute_to_class = wrap_fk_monkey_patch(ForeignKey.__init__, ForeignKey.contribute_to_class)

--- a/src/compositekey/db/models/manager.py
+++ b/src/compositekey/db/models/manager.py
@@ -1,8 +1,12 @@
+import logging
+
 from django.db.models.manager import Manager
 
 __author__ = 'aldaran'
 
 __all__ = ["activate_insert_query_monkey_patch"]
+
+log = logging.getLogger(__name__)
 
 def wrap_insert_query(original_insert_query):
 
@@ -17,5 +21,6 @@ def wrap_insert_query(original_insert_query):
 def activate_insert_query_monkey_patch():
     # monkey patch
     if not hasattr(Manager._insert, "_sign"):
-        print "activate_insert_query_monkey_patch"
+        log.debug("activate_insert_query_monkey_patch")
         Manager._insert =  wrap_insert_query(Manager._insert)
+        

--- a/src/compositekey/db/models/options.py
+++ b/src/compositekey/db/models/options.py
@@ -1,4 +1,5 @@
 import itertools
+import logging
 
 __author__ = 'aldaran'
 
@@ -8,6 +9,8 @@ from django.db.models.options import Options
 def get_fields_with_model(self):
     return [(field, model) for field, model in self._get_fields_with_model() if not getattr(field, "not_in_db", False)]
 get_fields_with_model._sign = "activate_get_fields_with_model_monkey_patch"
+
+log = logging.getLogger(__name__)
 
 def init_name_map(self):
     """
@@ -49,7 +52,7 @@ def nodb_names(self):
 def activate_get_fields_with_model_monkey_patch():
     # monkey patch
     if not hasattr(Options.get_fields_with_model, "_sign"):
-        print "activate_get_fields_with_model_monkey_patch"
+        log.debug("activate_get_fields_with_model_monkey_patch")
         Options._get_fields_with_model = Options.get_fields_with_model
         Options.get_fields_with_model = get_fields_with_model
         Options.init_name_map = init_name_map

--- a/src/compositekey/db/models/query.py
+++ b/src/compositekey/db/models/query.py
@@ -1,9 +1,12 @@
+import logging
+
 from django.db.models.query import get_cached_row, get_klass_info
 from compositekey.db.models.query_utils import new_deferred_class_factory as deferred_class_factory
 from compositekey.utils import *
 
 __author__ = 'aldaran'
 
+log = logging.getLogger(__name__)
 
 def iterator(self):
     """
@@ -152,9 +155,8 @@ def activate_iterator_monkey_patch():
     from django.db.models.query import QuerySet, ValuesQuerySet, ValuesListQuerySet
     # monkey patch
     if not hasattr(QuerySet.iterator, "_sign"):
-        print "activate_iterator_monkey_patch"
+        log.debug("activate_iterator_monkey_patch")
         QuerySet.iterator = iterator
         ValuesQuerySet.iterator = v_iterator
         ValuesListQuerySet.iterator = vl_iterator
         QuerySet._update = wrap_update(QuerySet._update)
-

--- a/src/compositekey/db/models/query_utils.py
+++ b/src/compositekey/db/models/query_utils.py
@@ -1,6 +1,10 @@
 __author__ = 'aldaran'
 
+import logging
+
 from django.db.models.query_utils import deferred_class_factory
+
+log = logging.getLogger(__name__)
 
 def new_deferred_class_factory(model, attrs):
     if hasattr(model._meta, "composite_special_fields"):
@@ -12,9 +16,10 @@ def activate_deferred_class_factory_monkey_patch():
     from django.db.models import query_utils, query, base
     # monkey patch
     if not hasattr(query_utils.deferred_class_factory, "_sign"):
-        print "activate_deferred_class_factory_monkey_patch"
+        log.debug("activate_deferred_class_factory_monkey_patch")
 
         # update all namespaces
         query_utils.deferred_class_factory = new_deferred_class_factory
         query.deferred_class_factory = new_deferred_class_factory
         base.deferred_class_factory = new_deferred_class_factory
+        

--- a/src/compositekey/db/models/sql/aggregates.py
+++ b/src/compositekey/db/models/sql/aggregates.py
@@ -1,4 +1,8 @@
 __author__ = 'aldaran'
+
+import logging
+
+log = logging.getLogger(__name__)
   
 def as_sql(self, qn, connection):
     "Return the aggregate, rendered as SQL."
@@ -45,6 +49,5 @@ def activate_as_sql_monkey_patch():
     from django.db.models.sql.aggregates import Aggregate
     # monkey patch
     if not hasattr(Aggregate.as_sql, "_sign"):
-        print "activate_as_sql_monkey_patch"
+        log.debug("activate_as_sql_monkey_patch")
         Aggregate.as_sql = as_sql
-

--- a/src/compositekey/db/models/sql/compiler.py
+++ b/src/compositekey/db/models/sql/compiler.py
@@ -1,3 +1,5 @@
+import logging
+
 from django.core.exceptions import FieldError
 from django.db.models.sql.constants import LHS_JOIN_COL, LHS_ALIAS, RHS_JOIN_COL, TABLE_NAME, JOIN_TYPE, LOOKUP_SEP
 from django.db.models.sql.query import get_order_dir
@@ -8,6 +10,8 @@ __author__ = 'aldaran'
 from django.db.models.sql.compiler import SQLCompiler
 
 __all__ = ["activate_get_from_clause_monkey_patch"]
+
+log = logging.getLogger(__name__)
 
 def wrap_get_from_clause(original_get_from_clause):
 
@@ -130,6 +134,6 @@ def find_ordering_name(self, name, opts, alias=None, default_order='ASC',
 def activate_get_from_clause_monkey_patch():
     # monkey patch
     if not hasattr(SQLCompiler.get_from_clause, "_sign"):
-        print "activate_get_from_clause_monkey_patch"
+        log.debug("activate_get_from_clause_monkey_patch")
         SQLCompiler.get_from_clause = wrap_get_from_clause(SQLCompiler.get_from_clause)
         SQLCompiler.find_ordering_name = find_ordering_name

--- a/src/compositekey/db/models/sql/query.py
+++ b/src/compositekey/db/models/sql/query.py
@@ -1,10 +1,13 @@
 __author__ = 'aldaran'
 
+import logging
+
 from django.core.exceptions import FieldError
 from django.db.models.sql.constants import LHS_JOIN_COL, RHS_JOIN_COL, LOOKUP_SEP, LHS_ALIAS
 from django.db.models.sql.datastructures import MultiJoin
 from django.db.models.sql.query import Query
 
+log = logging.getLogger(__name__)
 
 def add_fields(self, field_names, allow_m2m=True):
     """
@@ -74,7 +77,7 @@ def get_loaded_field_names_cb(self, target, model, fields):
 def activate_add_fields_monkey_patch():
     # monkey patch
     if not hasattr(Query.add_fields, "_sign"):
-        print "activate_add_fields_monkey_patch"
+        log.debug("activate_add_fields_monkey_patch")
         Query.add_fields = add_fields
         Query.deferred_to_columns_cb = deferred_to_columns_cb
         Query.get_loaded_field_names_cb = get_loaded_field_names_cb

--- a/src/compositekey/db/models/sql/subqueries.py
+++ b/src/compositekey/db/models/sql/subqueries.py
@@ -1,5 +1,7 @@
 __author__ = 'aldaran'
 
+import logging
+
 from django.db.models.sql.subqueries import DeleteQuery
 from django.db.models.sql.constants import *
 from django.db.models.sql.where import AND
@@ -8,6 +10,8 @@ from compositekey.db.models.sql.wherein import MultipleColumnsIN
 from compositekey.utils import *
 
 __all__ =["activate_delete_monkey_patch"]
+
+log = logging.getLogger(__name__)
 
 def wrap_delete_batch(original_delete_batch):
     from compositekey.utils import disassemble_pk
@@ -42,5 +46,5 @@ def wrap_delete_batch(original_delete_batch):
 def activate_delete_monkey_patch():
     # monkey patch
     if not hasattr(DeleteQuery.delete_batch, "_sign"):
-        print "activate_delete_monkey_patch"
+        log.debug("activate_delete_monkey_patch")
         DeleteQuery.delete_batch = wrap_delete_batch(DeleteQuery.delete_batch)

--- a/src/compositekey/db/models/sql/where.py
+++ b/src/compositekey/db/models/sql/where.py
@@ -1,6 +1,9 @@
+import logging
+
 from django.db.models.fields import Field
 from django.db.models.sql.where import EmptyShortCircuit, EmptyResultSet, WhereNode, Constraint
 
+log = logging.getLogger(__name__)
 
 def wrap_make_atom(original_make_atom):
     def make_atom(self, child, qn, connection):
@@ -45,6 +48,6 @@ def wrap_process(original):
 def activate_make_atom_monkey_patch():
     # monkey patch
     if not hasattr(WhereNode.make_atom, "_sign"):
-        print "activate_make_atom_monkey_patch"
+        log.debug("activate_make_atom_monkey_patch")
         WhereNode.make_atom = wrap_make_atom(WhereNode.make_atom)
         Constraint.process = wrap_process(Constraint.process)

--- a/src/compositekey/forms/models.py
+++ b/src/compositekey/forms/models.py
@@ -1,9 +1,13 @@
 __author__ = 'aldaran'
 
+import logging
+
 from django.forms import models
 from django.utils.datastructures import SortedDict
 
 __all__ = ["activate_modelform_monkey_patch"]
+
+log = logging.getLogger(__name__)
 
 def wrap_construct_instance(original_construct_instance):
     def construct_instance(form, instance, fields=None, exclude=None):
@@ -160,7 +164,7 @@ def wrap_get_foreign_key(original_get_foreign_key):
 def activate_modelform_monkey_patch():
     # monkey patch
     if not hasattr(models.fields_for_model, "_sign"):
-        print "activate_modelform_monkey_patch"
+        log.debug("activate_modelform_monkey_patch")
         setattr(models, "fields_for_model", wrap_fields_for_model(models.fields_for_model))
         setattr(models, "model_to_dict", wrap_model_to_dict(models.model_to_dict))
         setattr(models, "construct_instance", wrap_construct_instance(models.construct_instance))


### PR DESCRIPTION
Hi, thanks for your work.Your package is quite good and I would like to use it. But there is one thing now, I dislike: 'print' usage on monkey-patch load. I think you should use logging and logger.debug instead. There is a commit, that changes this. Thank you another time.
